### PR TITLE
Modify Oscillator.cpp & .h for a click-free stop.

### DIFF
--- a/app/src/main/cpp/Oscillator.h
+++ b/app/src/main/cpp/Oscillator.h
@@ -29,8 +29,9 @@ public:
     void render(float *audioData, int32_t numFrames);
 
 private:
-    // We use an atomic bool to define isWaveOn_ because it is accessed from multiple threads.
+    // Atomic bool is used for isWaveOn_ & isRunning_ because both are accessed from multiple threads.
     std::atomic<bool> isWaveOn_{false};
+    std::atomic<bool> isRunning_{false};
     double phase_ = 0.0;
     double phaseIncrement_ = 0.0;
 };


### PR DESCRIPTION
In the Codelab "Making Waves Part 1 - Build a Synthesizer", on the page "Build the Oscillator", there is a comment regarding "Cliicks and pops":

"We reset phase_ to zero each time the wave is switched off so that the wave always starts with a sample value of zero. If we didn't do this we'd sometimes hear an annoying "click" sound each time the wave was switched on.

Unfortunately we may still hear a click when we stop touching the screen because the final sample is much larger than the zeros that will follow after the wave is turned off. The discontinuity in the wave is what causes the click. One solution would be to apply a gradual fade out to the last buffer of data."

This contribution addresses the last part by eliminating the click when the touch stops. It also prevents the click when touch starts in a more elegant way.

A much more subtle effect may now be heard at the end. While the discontinuity in value has been removed there, a discontinuity in slope remains. However, this is symmetric with the effect at the beginning, at least in a mathematical sense, if not perceptually.